### PR TITLE
Hide empty descriptions in sequence diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ This config file is intended to simplify the look of Class/Sequence/State
 diagrams to meet the standard set for SENG301.
 It uses monochrome by default, but this can be overriden if needed.
 
-Due to missing formatting options, the user should use Activity syntax for State
-diagrams, and Class syntax for Object diagrams, in order to get the desired 
-look.
+Due to missing formatting options, the user should use Class syntax for
+Object diagrams, in order to get the desired look.
 
 ### Usage:
 
@@ -45,10 +44,9 @@ Keep in mind that double underscores are used to denote underlines.
 
 #### State Diagrams:
 
-For State diagrams, use the syntax for Activity diagrams, as they look the 
-same, with the exception of Activities look how the prof wants States.
-
-
+State diagrams work properly, however you need to add line breaks in your
+arrow descriptions using '\n' to ensure that the descriptions do not
+become too long.
 
 _There are a few other minor Syntactical quirks, but most can be easily 
 worked around._

--- a/SENG301.config
+++ b/SENG301.config
@@ -1,8 +1,8 @@
 /' 
 2015 University of Calgary SENG301 PlantUML Unofficial Config File
 By: Mikhael Boyle
-Version: 1.0.0
-Last Modified: 01/10/2015
+Version: 1.0.1
+Last Modified: 14/10/2015
 
 Description:
 
@@ -10,9 +10,8 @@ This config file is intended to simplify the look of Class/Sequence/State
 diagrams to meet the standard set for SENG301.
 It uses monochrome by default, but this can be overriden if needed.
 
-Due to missing formatting options, one should use Activity syntax for State
-diagrams, and Class syntax for Object diagrams, in order to get the desired 
-look.
+Due to missing formatting options, one should use Class syntax for Object
+diagrams, in order to get the desired look.
 
 Usage:
 
@@ -37,15 +36,14 @@ It is recommended that you use Class diagrams for Object diagrams as well,
 because Objects cannot be given aliases and : can't be used in names. 
 Keep in mind that double underscores are used to denote underlines.
 
-For State diagrams, use the syntax for Activity diagrams, as they look the 
-same, with the exception of Activities look how the prof wants States.
-
-There are a few other minor Syntactical quirks, but most can be easily 
-worked around.
+State diagrams work properly, however you need to add line breaks in your
+arrow descriptions using '\n' to ensure that the descriptions do not
+become too long.
 '/
 
 hide circles
 hide empty members
+hide empty description
 hide footbox
 
 skinparam monochrome true


### PR DESCRIPTION
I found a command for turning off the empty description part for sequence diagrams. This makes sequence diagrams look the way the prof wants them and eliminates the need to use activity diagrams instead, as activity diagrams don't seem to like square brackets in arrow labels.
